### PR TITLE
Fix docstring.

### DIFF
--- a/ace-isearch.el
+++ b/ace-isearch.el
@@ -66,8 +66,8 @@ during isearch."
   :group 'ace-isearch)
 
 (defcustom ace-isearch-input-length 6
-  "Length of inpunt string during isearch which is required to invoke
-`ace-isearch-function-from-isearch'."
+  "Length of inpunt string required for invoking
+`ace-isearch-function-from-isearch' during isearch."
   :type 'integer
   :group 'ace-isearch)
 


### PR DESCRIPTION
Fix docstring of `ace-isearch-input-length` to clarify its meaning.
