### PR TITLE
Fix for Emacs 25 (wrong-type-argument stringp nil)

### DIFF
--- a/ace-isearch.el
+++ b/ace-isearch.el
@@ -184,7 +184,6 @@ of `isearch-string' is longer than or equal to `ace-isearch-input-length'."
               (ace-isearch--fboundp ace-isearch-function-from-isearch
                 ace-isearch-use-function-from-isearch)
               (sit-for ace-isearch-func-delay))
-         (isearch-exit)
          (funcall ace-isearch-function-from-isearch))))
 
 (defun ace-isearch-pop-mark ()


### PR DESCRIPTION
Hey @tam17aki,

It still does work in Emacs 24 when I remove this line, at least I couldn't see any drawbacks
from it. Probably because `helm-swoop-from-isearch` also calls `(isearch-exit)`.

Maybe related to #19 

regards,
Christian