### PR TITLE
Workaround for Emacs 25.1

### DIFF
--- a/ace-isearch.el
+++ b/ace-isearch.el
@@ -175,7 +175,8 @@ of `isearch-string' is longer than or equal to `ace-isearch-input-length'."
              (message "Notice: Character '%s' could not be found in the \"selected visible window\"." isearch-string))
          (funcall ace-isearch-function (string-to-char isearch-string))
          ;; work-around for emacs 25.1
-         (setq isearch-lazy-highlight nil))
+         (setq isearch--current-buffer (buffer-name (current-buffer)))
+         (setq isearch-string ""))
 
         ((and (> (length isearch-string) 1)
               (< (length isearch-string) ace-isearch-input-length)
@@ -193,7 +194,8 @@ of `isearch-string' is longer than or equal to `ace-isearch-input-length'."
          (isearch-exit)
          (funcall ace-isearch-function-from-isearch)
          ;; work-around for emacs 25.1
-         (setq isearch-lazy-highlight nil))))
+         (setq isearch--current-buffer (buffer-name (current-buffer)))
+         (setq isearch-string "")))))
 
 (defun ace-isearch-pop-mark ()
   "Jump back to the last location of `ace-jump-mode' invoked or `avy-push-mark'."

--- a/ace-isearch.el
+++ b/ace-isearch.el
@@ -175,8 +175,7 @@ of `isearch-string' is longer than or equal to `ace-isearch-input-length'."
              (message "Notice: Character '%s' could not be found in the \"selected visible window\"." isearch-string))
          (funcall ace-isearch-function (string-to-char isearch-string))
          ;; work-around for emacs 25.1
-         (setq isearch--current-buffer (buffer-name))
-         (isearch-exit))
+         (setq isearch-lazy-highlight nil))
 
         ((and (> (length isearch-string) 1)
               (< (length isearch-string) ace-isearch-input-length)
@@ -194,8 +193,7 @@ of `isearch-string' is longer than or equal to `ace-isearch-input-length'."
          (isearch-exit)
          (funcall ace-isearch-function-from-isearch)
          ;; work-around for emacs 25.1
-         (setq isearch--current-buffer (buffer-name))
-         (isearch-exit))))
+         (setq isearch-lazy-highlight nil))))
 
 (defun ace-isearch-pop-mark ()
   "Jump back to the last location of `ace-jump-mode' invoked or `avy-push-mark'."

--- a/ace-isearch.el
+++ b/ace-isearch.el
@@ -175,8 +175,8 @@ of `isearch-string' is longer than or equal to `ace-isearch-input-length'."
              (message "Notice: Character '%s' could not be found in the \"selected visible window\"." isearch-string))
          (funcall ace-isearch-function (string-to-char isearch-string))
          ;; work-around for emacs 25.1
-         (setq isearch--current-buffer (buffer-name (current-buffer)))
-         (setq isearch-string ""))
+         (setq isearch--current-buffer (buffer-name (current-buffer))
+               isearch-string ""))
 
         ((and (> (length isearch-string) 1)
               (< (length isearch-string) ace-isearch-input-length)
@@ -194,8 +194,8 @@ of `isearch-string' is longer than or equal to `ace-isearch-input-length'."
          (isearch-exit)
          (funcall ace-isearch-function-from-isearch)
          ;; work-around for emacs 25.1
-         (setq isearch--current-buffer (buffer-name (current-buffer)))
-         (setq isearch-string "")))))
+         (setq isearch--current-buffer (buffer-name (current-buffer))
+               isearch-string ""))))
 
 (defun ace-isearch-pop-mark ()
   "Jump back to the last location of `ace-jump-mode' invoked or `avy-push-mark'."

--- a/ace-isearch.el
+++ b/ace-isearch.el
@@ -175,8 +175,7 @@ of `isearch-string' is longer than or equal to `ace-isearch-input-length'."
              (message "Notice: Character '%s' could not be found in the \"selected visible window\"." isearch-string))
          (funcall ace-isearch-function (string-to-char isearch-string))
          ;; work-around for emacs 25.1
-         (isearch-done)
-         (isearch-clean-overlays))
+         (isearch-exit))
 
         ((and (> (length isearch-string) 1)
               (< (length isearch-string) ace-isearch-input-length)
@@ -194,8 +193,7 @@ of `isearch-string' is longer than or equal to `ace-isearch-input-length'."
          (isearch-exit)
          (funcall ace-isearch-function-from-isearch)
          ;; work-around for emacs 25.1
-         (isearch-done)
-         (isearch-clean-overlays))))
+         (isearch-exit))))
 
 (defun ace-isearch-pop-mark ()
   "Jump back to the last location of `ace-jump-mode' invoked or `avy-push-mark'."

--- a/ace-isearch.el
+++ b/ace-isearch.el
@@ -168,12 +168,15 @@ of `isearch-string' is longer than or equal to `ace-isearch-input-length'."
                     (and (eq ace-isearch-use-jump 'printing-char)
                          (eq this-command 'isearch-printing-char))))
               (sit-for ace-isearch-jump-delay))
-         (isearch-done)
+         (isearch-exit)
          ;; go back to the point where isearch started
          (goto-char isearch-opoint)
          (if (or (< (point) (window-start)) (> (point) (window-end)))
              (message "Notice: Character '%s' could not be found in the \"selected visible window\"." isearch-string))
-         (funcall ace-isearch-function (string-to-char isearch-string)))
+         (funcall ace-isearch-function (string-to-char isearch-string))
+         ;; work-around for emacs 25.1
+         (isearch-done)
+         (isearch-clean-overlays))
 
         ((and (> (length isearch-string) 1)
               (< (length isearch-string) ace-isearch-input-length)
@@ -188,8 +191,11 @@ of `isearch-string' is longer than or equal to `ace-isearch-input-length'."
               (ace-isearch--fboundp ace-isearch-function-from-isearch
                 ace-isearch-use-function-from-isearch)
               (sit-for ace-isearch-func-delay))
+         (isearch-exit)
+         (funcall ace-isearch-function-from-isearch)
+         ;; work-around for emacs 25.1
          (isearch-done)
-         (funcall ace-isearch-function-from-isearch))))
+         (isearch-clean-overlays))))
 
 (defun ace-isearch-pop-mark ()
   "Jump back to the last location of `ace-jump-mode' invoked or `avy-push-mark'."

--- a/ace-isearch.el
+++ b/ace-isearch.el
@@ -175,6 +175,7 @@ of `isearch-string' is longer than or equal to `ace-isearch-input-length'."
              (message "Notice: Character '%s' could not be found in the \"selected visible window\"." isearch-string))
          (funcall ace-isearch-function (string-to-char isearch-string))
          ;; work-around for emacs 25.1
+         (setq isearch--current-buffer (buffer-name))
          (isearch-exit))
 
         ((and (> (length isearch-string) 1)
@@ -193,6 +194,7 @@ of `isearch-string' is longer than or equal to `ace-isearch-input-length'."
          (isearch-exit)
          (funcall ace-isearch-function-from-isearch)
          ;; work-around for emacs 25.1
+         (setq isearch--current-buffer (buffer-name))
          (isearch-exit))))
 
 (defun ace-isearch-pop-mark ()

--- a/ace-isearch.el
+++ b/ace-isearch.el
@@ -168,7 +168,7 @@ of `isearch-string' is longer than or equal to `ace-isearch-input-length'."
                     (and (eq ace-isearch-use-jump 'printing-char)
                          (eq this-command 'isearch-printing-char))))
               (sit-for ace-isearch-jump-delay))
-         (isearch-exit)
+         (isearch-done)
          ;; go back to the point where isearch started
          (goto-char isearch-opoint)
          (if (or (< (point) (window-start)) (> (point) (window-end)))
@@ -188,7 +188,7 @@ of `isearch-string' is longer than or equal to `ace-isearch-input-length'."
               (ace-isearch--fboundp ace-isearch-function-from-isearch
                 ace-isearch-use-function-from-isearch)
               (sit-for ace-isearch-func-delay))
-         (isearch-exit)
+         (isearch-done)
          (funcall ace-isearch-function-from-isearch))))
 
 (defun ace-isearch-pop-mark ()


### PR DESCRIPTION
This fix is a workaround of the problem on emacs 25.1, that search query is kept highlighted after exiting the ace-search.