### PR TITLE
Adding 2-character jumping

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,24 +2,24 @@ ace-isearch [![MELPA](http://melpa.org/packages/ace-isearch-badge.svg)](http://m
 ===========
 
 ## Introduction
-`ace-isearch.el` provides a minor mode which combines `isearch`,  [`ace-jump-mode`](https://github.com/winterTTr/ace-jump-mode) or
+`ace-isearch.el` provides a minor mode that combines `isearch`,  [`ace-jump-mode`](https://github.com/winterTTr/ace-jump-mode) or
 [`avy`](https://github.com/abo-abo/avy) and
 [`helm-swoop`](https://github.com/ShingoFukuyama/helm-swoop) or [`swiper`](https://github.com/abo-abo/swiper/).
 
-The "default" behavior (`ace-isearch-jump-based-on-one-char` = t) can be summarized as:
+The "default" behavior (`ace-isearch-jump-based-on-one-char` t) can be summarized as:
 - L = 1     : `ace-jump-mode` or `avy`
 - 1 < L < 6 : `isearch`
 - L >= 6    : `helm-swoop` or `swiper`
 
-where L is the length of input query string during `isearch`.  When L is 1, after a
+where L is the input string length during `isearch`.  When L is 1, after a
 few seconds specified by `ace-isearch-jump-delay`, `ace-jump-mode` or `avy` will
 be invoked. Of course you can customize the above behaviour.
 
-If `ace-isearch-jump-based-on-one-char` = nil, L=2 characters are required to
+If (`ace-isearch-jump-based-on-one-char` nil), L=2 characters are required to
 invoke `ace-jump-mode` or `avy` after `ace-isearch-jump-delay`. This has the effect
 of doing regular `isearch` for L=1 and L=3 to 6, with the ability to switch to
 2-character `avy` or `ace-jump-mode` (not yet supported) once `ace-isearch-jump-delay`
-is passed. Much easier to do than to write about :-)
+has passed. Much easier to do than to write about :-)
 
 ## Requirements
 
@@ -70,7 +70,8 @@ You should specify `ace-jump-word-mode`, `ace-jump-char-mode`,
 #### `ace-isearch-2-function` (Default:`avy-goto-char-2`)
 Specify the function name utilized in invoking `ace-jump-mode` or `avy`
 when 2-character jumping is enabled (`ace-isearch-jump-based-on-one-char` = nil).
-Currently, only `avy-goto-char-2` is available.
+Currently, only `avy` functions `avy-goto-char-2`, `avy-goto-char-2-above` and
+`avy-goto-char-2-below` are available.
 
 ---
 
@@ -81,7 +82,7 @@ interactively.
 ---
 
 #### `ace-isearch-use-jump` (Default:`t`)
-If this variable is set to `nil`, `ace-jump-mode` or `avy` is never invoked.
+If this variable is set to `nil`, `ace-jump-mode` or `avy` are never invoked.
 
 If set to `t`, it is always invoked if the length of `isearch-string` is equal to 1.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ ace-isearch [![MELPA](http://melpa.org/packages/ace-isearch-badge.svg)](http://m
 [`avy`](https://github.com/abo-abo/avy) and
 [`helm-swoop`](https://github.com/ShingoFukuyama/helm-swoop) or [`swiper`](https://github.com/abo-abo/swiper/).
 
-The "default" behavior can be summarized as:
+The "default" behavior (`ace-isearch-jump-based-on-one-char` = t) can be summarized as:
 - L = 1     : `ace-jump-mode` or `avy`
 - 1 < L < 6 : `isearch`
 - L >= 6    : `helm-swoop` or `swiper`
@@ -14,6 +14,12 @@ The "default" behavior can be summarized as:
 where L is the length of input query string during `isearch`.  When L is 1, after a
 few seconds specified by `ace-isearch-jump-delay`, `ace-jump-mode` or `avy` will
 be invoked. Of course you can customize the above behaviour.
+
+If `ace-isearch-jump-based-on-one-char` = nil, L=2 characters are required to
+invoke `ace-jump-mode` or `avy` after `ace-isearch-jump-delay`. This has the effect
+of doing regular `isearch` for L=1 and L=3 to 6, with the ability to switch to
+2-character `avy` or `ace-jump-mode` (not yet supported) once `ace-isearch-jump-delay`
+is passed. Much easier to do than to write about :-)
 
 ## Requirements
 
@@ -54,14 +60,23 @@ Enable global ace-isearch mode:
 ## Customization
 
 #### `ace-isearch-function` (Default:`ace-jump-word-mode`)
-Specify the function name utilized in invoking `ace-jump-mode` or `avy`.
+Specify the function name utilized in invoking `ace-jump-mode` or `avy`
+when 1-character jumping is enabled (`ace-isearch-jump-based-on-one-char` = t).
 You should specify `ace-jump-word-mode`, `ace-jump-char-mode`, 
 `avy-goto-word-1`, `avy-goto-subword-1`, or `avy-goto-char`.
 
 ---
 
-#### `ace-isearch-switch-function`
-You can switch the value of `ace-isearch-function` interactively.
+#### `ace-isearch-2-function` (Default:`avy-goto-char-2`)
+Specify the function name utilized in invoking `ace-jump-mode` or `avy`
+when 2-character jumping is enabled (`ace-isearch-jump-based-on-one-char` = nil).
+Currently, only `avy-goto-char-2` is available.
+
+---
+
+#### `ace-isearch-switch-function` or `ace-isearch-2-switch-function`
+You can switch the value of `ace-isearch-function` or `ace-isearch-2-function`
+interactively.
 
 ---
 
@@ -73,6 +88,11 @@ If set to `t`, it is always invoked if the length of `isearch-string` is equal t
 If set to `printing-char`, it is invoked only if you hit a printing character to search for as a first input.
 This prevents it from being invoked when repeating a one character search, yanking a character or calling
 `isearch-delete-char` leaving only one character.
+
+---
+
+#### `ace-isearch-jump-based-on-one-char` (Default:`t`)
+If this variable is set to `nil`, 2-character jumping is used, with L=2 invoking `ace-jump-mode` or `avy` instead of L=1.
 
 ---
 
@@ -158,7 +178,7 @@ This helps to reduce many key repeats of `C-s` or `C-r`.
 ---
 
 #### `ace-isearch-pop-mark`
-You can invoke `ace-jump-mode-pop-mark` or `avy-pop-mark` in accordance with the current `ace-isearch-funciton`. With this function, you can jump back to the last location of `ace-jump-mode` or `avy`.
+You can invoke `ace-jump-mode-pop-mark` or `avy-pop-mark` in accordance with the current `ace-isearch-function` or `ace-isearch-2-function`. With this function, you can jump back to the last location of `ace-jump-mode` or `avy`.
 
 ## Sample Configuration
 ```el

--- a/ace-isearch.el
+++ b/ace-isearch.el
@@ -319,7 +319,11 @@ of `isearch-string' is longer than or equal to `ace-isearch-input-length'."
   (if ace-isearch-mode
       (progn
         (add-hook 'isearch-update-post-hook 'ace-isearch--jumper-function nil t)
-        (ace-isearch--make-ace-jump-or-avy))
+        (if ace-isearch-jump-based-on-one-char
+            (ace-isearch--make-ace-jump-or-avy)
+          (ace-isearch-2--make-ace-jump-or-avy)
+          )
+        )
     (remove-hook 'isearch-update-post-hook 'ace-isearch--jumper-function t)))
 
 (defun ace-isearch--turn-on ()

--- a/ace-isearch.el
+++ b/ace-isearch.el
@@ -23,10 +23,10 @@
 
 ;;; Commentary:
 ;;
-;; `ace-isearch.el' provides a minor mode which combines `isearch',
+;; `ace-isearch.el' provides a minor mode that combines `isearch',
 ;; `ace-jump-mode', `avy', `helm-swoop' and `swiper'.
 ;;
-;; The "default" behavior (`ace-isearch-jump-based-on-one-char' = t) can be
+;; The "default" behavior (`ace-isearch-jump-based-on-one-char' t) can be
 ;; summarized as:
 ;;
 ;; L = 1     : `ace-jump-mode' or `avy'
@@ -37,11 +37,11 @@
 ;; few seconds specified by `ace-isearch-jump-delay', `ace-jump-mode' or `avy'
 ;; will be invoked. Of course you can customize the above behaviour.
 ;;
-;; If `ace-isearch-jump-based-on-one-char' = nil, L=2 characters are required
+;; If (`ace-isearch-jump-based-on-one-char' nil), L=2 characters are required
 ;; to invoke `ace-jump-mode' or `avy' after `ace-isearch-jump-delay'. This has
 ;; the effect of doing regular `isearch' for L=1 and L=3 to 6, with the ability
 ;; to switch to 2-character `avy' or `ace-jump-mode' (not yet supported) once
-;; `ace-isearch-jump-delay' is passed. Much easier to do than to write about :-)
+;; `ace-isearch-jump-delay' has passed. Much easier to do than to write about :-)
 
 ;;; Installation:
 ;;
@@ -68,8 +68,9 @@
 
 (defcustom ace-isearch-2-function 'avy-goto-char-2
   "Function name to invoke ace-jump-mode or avy based on 2 characters."
-  :type '(choice 
-          (const :tag "Use avy-goto-char-2." avy-goto-char-2))
+  :type '(choice (const :tag "Use avy-goto-char-2." avy-goto-char-2)
+                 (const :tag "Use avy-goto-char-2-above." avy-goto-char-2-above)
+                 (const :tag "Use avy-goto-char-2-below." avy-goto-char-2-below))
   :group 'ace-isearch)
 
 (if (not (require 'ace-jump-mode nil 'noerror))
@@ -90,7 +91,7 @@ is longer than or equal to `ace-isearch-input-length'."
                  (setq ace-isearch-function-from-isearch 'helm-occur-from-isearch)
                nil)))
     (if (require 'swiper nil 'noerror)
-	(setq ace-isearch-function-from-isearch 'ace-isearch-swiper-from-isearch)
+        (setq ace-isearch-function-from-isearch 'ace-isearch-swiper-from-isearch)
       (user-error "You need to install either helm-swoop, helm-occur or swiper.")))
 
 (defcustom ace-isearch-lighter " AceI"
@@ -144,7 +145,7 @@ of `isearch-string' is longer than or equal to `ace-isearch-input-length'."
   :group 'ace-isearch)
 
 (defcustom ace-isearch-fallback-function 'ace-isearch-helm-swoop-from-isearch
-  "Symbol name of function which is invoked when isearch fails and
+  "Symbol name of function that is invoked when isearch fails and
 `ace-isearch-use-fallback-function' is non-nil."
   :type 'symbol
   :group 'ace-isearch)
@@ -165,15 +166,16 @@ of `isearch-string' is longer than or equal to `ace-isearch-input-length'."
         "avy-goto-word-or-subword-1" "avy-goto-char"))
 
 (defvar ace-isearch--avy-2-function-list
-  (list "avy-goto-char-2"))
+  (list "avy-goto-char-2" "avy-goto-char-2-above"
+        "avy-goto-char-2-below"))
 
 (defvar ace-isearch--function-list
   (append ace-isearch--ace-jump-function-list ace-isearch--avy-function-list)
-  "List of functions to jumping using 1 character.")
+  "List of functions for jumping using 1 character.")
 
 (defvar ace-isearch-2--function-list
   (append ace-isearch--ace-jump-2-function-list ace-isearch--avy-2-function-list)
-  "List of functions to jumping using 1 character.")
+  "List of functions for jumping using 2 characters.")
 
 (defvar ace-isearch--ace-jump-or-avy)
 
@@ -199,7 +201,7 @@ of `isearch-string' is longer than or equal to `ace-isearch-input-length'."
                ace-isearch-2--function-list nil t)
               ))
     (setq ace-isearch-2-function (intern-soft func))
-    (ace-isearch--make-ace-jump-or-avy)
+    (ace-isearch-2--make-ace-jump-or-avy)
     (message "Function for ace-isearch-2 is set to %s." func)))
 
 (defun ace-isearch--fboundp (func flag)
@@ -325,7 +327,7 @@ of `isearch-string' is longer than or equal to `ace-isearch-input-length'."
 
 ;;;###autoload
 (define-minor-mode ace-isearch-mode
-  "Minor-mode which combines isearch, ace-jump-mode, avy, helm-swoop and swiper seamlessly."
+  "Minor-mode that combines isearch, ace-jump-mode, avy, helm-swoop and swiper seamlessly."
   :group      'ace-isearch
   :init-value nil
   :global     nil

--- a/ace-isearch.el
+++ b/ace-isearch.el
@@ -26,7 +26,7 @@
 ;; `ace-isearch.el' provides a minor mode which combines `isearch',
 ;; `ace-jump-mode', `avy', `helm-swoop' and `swiper'.
 ;;
-;; The "default" behavior can be summrized as:
+;; The "default" behavior can be summarized as:
 ;;
 ;; L = 1     : `ace-jump-mode' or `avy'
 ;; 1 < L < 6 : `isearch'
@@ -248,7 +248,7 @@ of `isearch-string' is longer than or equal to `ace-isearch-input-length'."
 
 ;;;###autoload
 (defun ace-isearch-jump-during-isearch ()
-  "Jump to the one of the current isearch candidates."
+  "Jump to one of the current isearch candidates."
   (interactive)
   (if (< (length isearch-string) ace-isearch-input-length)
       (cond ((eq ace-isearch--ace-jump-or-avy 'ace-jump)

--- a/ace-isearch.el
+++ b/ace-isearch.el
@@ -188,6 +188,17 @@ of `isearch-string' is longer than or equal to `ace-isearch-input-length'."
     (ace-isearch--make-ace-jump-or-avy)
     (message "Function for ace-isearch is set to %s." func)))
 
+(defun ace-isearch-2-switch-function ()
+  (interactive)
+  (let ((func (completing-read
+               (format "Function for ace-isearch-2 (current is %s): "
+                       ace-isearch-2-function)
+               ace-isearch-2--function-list nil t)
+              ))
+    (setq ace-isearch-2-function (intern-soft func))
+    (ace-isearch--make-ace-jump-or-avy)
+    (message "Function for ace-isearch-2 is set to %s." func)))
+
 (defun ace-isearch--fboundp (func flag)
   (declare (indent 1))
   (when flag
@@ -253,6 +264,17 @@ of `isearch-string' is longer than or equal to `ace-isearch-input-length'."
           (t
            (error (format "Function name %s for ace-isearch is invalid!"
                           ace-isearch-function))))))
+
+(defun ace-isearch-2--make-ace-jump-or-avy ()
+  (let ((func-str (format "%s" ace-isearch-2-function)))
+    (cond ((member func-str ace-isearch-2--function-list)
+           (cond ((member func-str ace-isearch--ace-jump-2-function-list)
+                  (setq ace-isearch--ace-jump-or-avy 'ace-jump))
+                 ((member func-str ace-isearch--avy-2-function-list)
+                  (setq ace-isearch--ace-jump-or-avy 'avy))))
+          (t
+           (error (format "Function name %s for ace-isearch-2 is invalid!"
+                          ace-isearch-2-function))))))
 
 (defun ace-isearch-helm-swoop-from-isearch ()
   "Invoke `helm-swoop' from ace-isearch."

--- a/ace-isearch.el
+++ b/ace-isearch.el
@@ -38,7 +38,10 @@
 ;; will be invoked. Of course you can customize the above behaviour.
 ;;
 ;; If `ace-isearch-jump-based-on-one-char' = nil, L=2 characters are required
-;; to invoke `ace-jump-mode' or `avy' after `ace-isearch-jump-delay'.
+;; to invoke `ace-jump-mode' or `avy' after `ace-isearch-jump-delay'. This has
+;; the effect of doing regular `isearch' for L=1 and L=3 to 6, with the ability
+;; to switch to 2-character `avy' or `ace-jump-mode' (not yet supported) once
+;; `ace-isearch-jump-delay' is passed. Much easier to do than to write about :-)
 
 ;;; Installation:
 ;;


### PR DESCRIPTION
Hi,

I've been using ace-isearch with avy for a while now (it really brings together the 3 search libraries into 1 intuitive interface), but could not live without avy's 2-character jumping functions (avy-goto-char-2, avy-goto-char-2-above and avy-goto-char-2-below). Hence this pull request.

Basically, I've added the `ace-isearch-jump-based-on-one-char` defcustom, which defaults to `t`, i.e., the old ace-isearch behaviour. When changed to `nil`, L=2 characters are required to
invoke `ace-jump-mode` or `avy` after `ace-isearch-jump-delay`. This has the effect of doing regular `isearch` for L=1 and L=3 to 6, with the ability to use 2-character jumping with `avy` or `ace-jump-mode` (not yet supported) for L=2 once `ace-isearch-jump-delay` has passed.

Personally, I find the `isearch` search for L=1 perfect to jump to the next 1 or 2 occurrences of a character while editing a sentence or statement, while L=2 allows further on-screen jumping without too many choices. This pull request does *not* combine 1- and 2-character jumping simultaneously, i.e., one has to choose one or the other using `ace-isearch-jump-based-on-one-char`.

Overview of the changes in the code:
- 2 new defcustoms (`ace-isearch-jump-based-on-one-char` and `ace-isearch-2-function`)
- 3 new defvars (`ace-isearch--ace-jump-2-function-list`, `ace-isearch--avy-2-function-list`, `ace-isearch-2--function-list`)
- 2 new variants of existing defuns (`ace-isearch-2-switch-function` and `ace-isearch-2--make-ace-jump-or-avy`)
- (limited) modifications to `ace-isearch--jumper-function` and `ace-isearch-mode`
- updates to documentation, README and comments
- no existing API changes

I hope these changes prove useful for inclusion in ace-isearch.

Bram