### PR TITLE
When using helm-occur there is a delay in opening the helm-occur window

### DIFF
--- a/ace-isearch.el
+++ b/ace-isearch.el
@@ -154,6 +154,11 @@ of `isearch-string' is longer than or equal to `ace-isearch-input-length'."
   :type 'boolean
   :group 'ace-isearch)
 
+(defcustom ace-isearch-on-evil-mode nil
+  "If non nil, ace-isearch-mode can be used on Evil mode."
+  :type 'boolean
+  :group 'ace-isearch)
+
 (defvar ace-isearch--ace-jump-function-list
   (list "ace-jump-word-mode" "ace-jump-char-mode"))
 
@@ -218,15 +223,18 @@ of `isearch-string' is longer than or equal to `ace-isearch-input-length'."
            2)))
     (cond (;; using avy/ace-jump since L=1 or L=2 reached (depending on `ace-isearch-jump-based-on-one-char')
            (and (= (length isearch-string) ace-isearch-input-min-length)
-                (and (or (not (ace-isearch--isearch-regexp-function))
+                (and (if ace-isearch-on-evil-mode
+                         t
+                       (not isearch-regexp))
+                     (or (not (ace-isearch--isearch-regexp-function))
                          (not (eq search-default-mode nil))))
                 (ace-isearch--fboundp (if ace-isearch-jump-based-on-one-char
-                                         ace-isearch-function ace-isearch-2-function)
+                                          ace-isearch-function ace-isearch-2-function)
                   (or (eq ace-isearch-use-jump t)
                       (and (eq ace-isearch-use-jump 'printing-char)
                            (eq this-command 'isearch-printing-char))))
                 (sit-for ace-isearch-jump-delay))
-           (isearch-done t t)
+           (isearch-done nil t)
            ;; go back to the point where isearch started
            (goto-char isearch-opoint)
            (if (or (< (point) (window-start)) (> (point) (window-end)))
@@ -250,6 +258,9 @@ of `isearch-string' is longer than or equal to `ace-isearch-input-length'."
 
           ;; switching from isearch to helm/swiper since `ace-isearch-input-length' reached
           ((and (>= (length isearch-string) ace-isearch-input-length)
+                (if ace-isearch-on-evil-mode
+                    t
+                  (not isearch-regexp))
                 (ace-isearch--fboundp ace-isearch-function-from-isearch
                   ace-isearch-use-function-from-isearch)
                 (sit-for ace-isearch-func-delay))
@@ -295,6 +306,7 @@ of `isearch-string' is longer than or equal to `ace-isearch-input-length'."
   (let (($query (if isearch-regexp
                     isearch-string
                   (regexp-quote isearch-string))))
+    (isearch-update-ring isearch-string isearch-regexp)
     (let (search-nonincremental-instead)
       (ignore-errors (isearch-done t t)))
     (helm-swoop :query $query)))
@@ -305,6 +317,7 @@ of `isearch-string' is longer than or equal to `ace-isearch-input-length'."
   (let (($query (if isearch-regexp
                     isearch-string
                   (regexp-quote isearch-string))))
+    (isearch-update-ring isearch-string isearch-regexp)
     (let (search-nonincremental-instead)
       (ignore-errors (isearch-done t t)))
     (swiper $query)))

--- a/ace-isearch.el
+++ b/ace-isearch.el
@@ -107,7 +107,7 @@ is longer than or equal to `ace-isearch-input-length'."
 
 (if (not (or (require 'helm-swoop nil 'noerror)
              (if (require 'helm-occur nil 'noerror)
-                 (setq ace-isearch-function-from-isearch 'helm-occur-from-isearch)
+                 (setq ace-isearch-function-from-isearch 'ace-isearch-helm-occur-from-isearch)
                nil)))
     (if (require 'swiper nil 'noerror)
         (setq ace-isearch-function-from-isearch 'ace-isearch-swiper-from-isearch)
@@ -253,7 +253,7 @@ of `isearch-string' is longer than or equal to `ace-isearch-input-length'."
                       (and (eq ace-isearch-use-jump 'printing-char)
                            (eq this-command 'isearch-printing-char))))
                 (sit-for ace-isearch-jump-delay))
-           (isearch-done nil t)
+           (isearch-done t t)
            ;; go back to the point where isearch started
            (goto-char isearch-opoint)
            (if (or (< (point) (window-start)) (> (point) (window-end)))
@@ -317,6 +317,18 @@ of `isearch-string' is longer than or equal to `ace-isearch-input-length'."
           (t
            (error (format "Function name %s for ace-isearch-2 is invalid!"
                           ace-isearch-2-function))))))
+
+(defun ace-isearch-helm-occur-from-isearch ()
+  "Invoke `helm-swoop' from ace-isearch."
+  (interactive)
+  (let ((bufs (list (current-buffer)))
+        ($query (if isearch-regexp
+                    isearch-string
+                  (regexp-quote isearch-string))))
+    (isearch-update-ring isearch-string isearch-regexp)
+    (let (search-nonincremental-instead)
+      (ignore-errors (isearch-done t t)))
+    (helm-multi-occur-1 bufs $query)))
 
 (defun ace-isearch-helm-swoop-from-isearch ()
   "Invoke `helm-swoop' from ace-isearch."

--- a/ace-isearch.el
+++ b/ace-isearch.el
@@ -221,7 +221,7 @@ of `isearch-string' is longer than or equal to `ace-isearch-input-length'."
                 (and (or (not (ace-isearch--isearch-regexp-function))
                          (not (eq search-default-mode nil))))
                 (ace-isearch--fboundp (if ace-isearch-jump-based-on-one-char
-                                          ace-isearch-function ace-isearch-2-function)
+                                         ace-isearch-function ace-isearch-2-function)
                   (or (eq ace-isearch-use-jump t)
                       (and (eq ace-isearch-use-jump 'printing-char)
                            (eq this-command 'isearch-printing-char))))
@@ -253,7 +253,7 @@ of `isearch-string' is longer than or equal to `ace-isearch-input-length'."
                 (ace-isearch--fboundp ace-isearch-function-from-isearch
                   ace-isearch-use-function-from-isearch)
                 (sit-for ace-isearch-func-delay))
-           (isearch-exit)
+           (isearch-done t t)
            (funcall ace-isearch-function-from-isearch)
            ;; work-around for emacs 25.1
            (setq isearch--current-buffer (buffer-name (current-buffer))


### PR DESCRIPTION
This delay causes the user to type into the buffer and thus causing unwanted typing