### PR TITLE
Add consult-line support and relax helm/swiper dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ ace-isearch [![MELPA](http://melpa.org/packages/ace-isearch-badge.svg)](http://m
 ## Introduction
 `ace-isearch.el` provides a minor mode that combines `isearch`,  [`ace-jump-mode`](https://github.com/winterTTr/ace-jump-mode) or
 [`avy`](https://github.com/abo-abo/avy) and
-[`helm-swoop`](https://github.com/ShingoFukuyama/helm-swoop) or [`swiper`](https://github.com/abo-abo/swiper/).
+[`helm-swoop`](https://github.com/ShingoFukuyama/helm-swoop), [`swiper`](https://github.com/abo-abo/swiper/) or [`consult-line`](https://github.com/minad/consult).
 
 The "default" behavior (`ace-isearch-jump-based-on-one-char` t) can be summarized as:
 - L = 1     : `ace-jump-mode` or `avy`
 - 1 < L < 6 : `isearch`
-- L >= 6    : `helm-swoop` or `swiper`
+- L >= 6    : `helm-swoop`, `swiper` or `consult-line`
 
 where L is the input string length during `isearch`.  When L is 1, after a
 few seconds specified by `ace-isearch-jump-delay`, `ace-jump-mode` or `avy` will
@@ -25,7 +25,7 @@ has passed. Much easier to do than to write about :-)
 
 * Emacs 24 or higher
 * [ace-jump-mode](https://github.com/winterTTr/ace-jump-mode) or [avy](https://github.com/abo-abo/avy)
-* [helm-swoop](https://github.com/ShingoFukuyama/helm-swoop) or [swiper](https://github.com/abo-abo/swiper/)
+* [helm-swoop](https://github.com/ShingoFukuyama/helm-swoop), [swiper](https://github.com/abo-abo/swiper/) or [consult](https://github.com/minad/consult)
 
 You must install these packages manually.
 
@@ -140,10 +140,23 @@ You can also set this variable to use `swiper`.
 (setq ace-isearch-function-from-isearch 'ace-isearch-swiper-from-isearch)
 ```
 
+Or you can set it to use `consult-line`.
+
+```el
+(setq ace-isearch-function-from-isearch 'ace-isearch-consult-line-from-isearch)
+```
+
 ---
 
 #### `ace-isearch-use-function-from-isearch` (Default:`t`)
 If you don't want to invoke `ace-isearch-function-from-isearch`, set this variable to `nil`.
+
+---
+
+#### `ace-isearch-disable-isearch-function-from-isearch-message` (Default:`nil`)
+In the event that none of the supported libraries are available for `ace-isearch-function-from-isearch`, a message will issue explaining the situtation.
+
+In order to disable the message, set this variable to `t`.
 
 ---
 


### PR DESCRIPTION
This relates to issue #42.

It adds support for `consult-line` and also allows `ace-isearch` to load even if none of the supported `ace-isearch-from-isearch` packages is available. 

(In that case, `ace-isearch-use-function-from-isearch` is set to nil, and an optional message issues explaining which packages the user would need to install in order for the feature to work.)

I hope it was not too presumptuous of me to remove the `user-error` call when neither helm nor swiper were installed.  It was preventing me from loading the package at all if those packages weren't present.  I think the package is still valuable, even when only used with `avy`.  But I like it even more with `consult-line`. :-D